### PR TITLE
Update documentation

### DIFF
--- a/content/docs/docker.md
+++ b/content/docs/docker.md
@@ -87,7 +87,7 @@ This would work well on Windows/Mac but what about Linux? Either docker-sync is 
 
 
 [dockerSync]: http://docker-sync.io
-[musketeersLambdaGoServerless]: https://gitlab.com/flemay/cookiecutter-musketeers-lambda-go-serverless/
+[musketeersLambdaGoServerless]: https://github.com/3musketeersio/cookiecutter-musketeers-lambda-go-serverless
 [golang]: https://hub.docker.com/_/golang/
 [dockerMusketeersRepo]: https://github.com/flemay/docker-musketeers
 [patterns]: ../patterns

--- a/content/docs/environment-variables.md
+++ b/content/docs/environment-variables.md
@@ -152,3 +152,4 @@ If you are using `~/.aws`, no need to set values and they won't be included in t
 [dockerEnvfile]: https://docs.docker.com/compose/env-file/
 [envvars]: https://github.com/flemay/envvars/
 [linkMakeTargetEnvfile]: ../make#targets-env-and-envfile
+[musketeersLambdaGoServerless]: https://github.com/3musketeersio/cookiecutter-musketeers-lambda-go-serverless

--- a/content/docs/get-started.md
+++ b/content/docs/get-started.md
@@ -39,7 +39,7 @@ services:
 
 # echo calls Compose to run the command "echo 'Hello World!'" in a Docker container
 echo:
-	docker-compose run alpine echo 'Hello World!'
+	docker-compose run --rm alpine echo 'Hello World!'
 ```
 
 Then simply echo "Hello World!" with the following command:

--- a/content/docs/make.md
+++ b/content/docs/make.md
@@ -24,7 +24,7 @@ test: $(GOLANG_DEPS_DIR)
 	$(COMPOSE_RUN_GOLANG) make _test
 .PHONY: test
 
-# _test target depends on a go environment which may not be available on the host but it is executed in a Docker container. If you have a go environment on your host, `$ make test` can also be called.
+# _test target depends on a go environment which may not be available on the host but it is executed in a Docker container. If you have a go environment on your host, `$ make _test` can also be called.
 _test:
 	go test
 .PHONY: _test
@@ -391,7 +391,7 @@ target01: This message will also show up when typing 'make help'
 target02: This message will show up too!!!
 ```
 
-[musketeersLambdaGoServerless]: https://gitlab.com/flemay/cookiecutter-musketeers-lambda-go-serverless/
+[musketeersLambdaGoServerless]: https://github.com/3musketeersio/cookiecutter-musketeers-lambda-go-serverless
 [phonyStackoverflow]: https://stackoverflow.com/questions/2145590/what-is-the-purpose-of-phony-in-a-makefile#2145605/
 [dockerCookiecutter]: https://gitlab.com/flemay/docker-cookiecutter
 [envvars]: https://github.com/flemay/envvars

--- a/content/docs/other-tips.md
+++ b/content/docs/other-tips.md
@@ -12,7 +12,7 @@ toc: true
 
 ## Accessing host's localhost
 
-On Windows/Mac, accessing the host localhost is to use the url like `docker.for.mac.localhost`. This is handy because if you have an application running on `localhost:3000` locally (through container or not), then you can access it `$ curl docker.for.mac.localhost:3000`.
+On Windows/Mac, accessing the host localhost is to use the url like `host.docker.internal`. This is handy because if you have an application running on `localhost:3000` locally (through container or not), then you can access it `$ curl host.docker.internal:3000`.
 
 ## Access environment variables in command argument
 
@@ -32,7 +32,7 @@ $ docker run --rm -e ECHO=musketeers alpine sh -c 'echo $ECHO'
 
 ## One shell script file
 
-It may happen to want to use a singular shell script file that contains the _targets. With the following, you can call the _targets like this `scripts/make.sh _test _clean`
+It may happen that you want to use a singular shell script file that contains the _targets. With the following, you can call the _targets like this `scripts/make.sh _test _clean`
 
 ```sh
 # scripts/make.sh

--- a/content/docs/patterns.md
+++ b/content/docs/patterns.md
@@ -30,7 +30,7 @@ services:
 ```Makefile
 # Makefile
 echo:
-	docker-compose run alpine make _echo
+	docker-compose run --rm alpine make _echo
 
 _echo:
 	echo 'Hello World!'


### PR DESCRIPTION
Includes:
  * Consistently use --rm when running docker/compose
  * Update cookiecutter url from gitlab to github location
  * Use host.docker.internal instead of mac specific url to host